### PR TITLE
DONE: #12 use more strcited warning mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(server)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-ggdb")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wpedantic -Werror -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wpedantic -Werror")
 set(CMAKE_CXX_FLAGS_SANITIZE "-Wall -Wpedantic -Werror -ggdb -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined")
 

--- a/mydisp.cpp
+++ b/mydisp.cpp
@@ -245,7 +245,7 @@ try {
     	dsockets::ErrorType errorType = socketsPoller->pollSockets( socketsList, reSocketsList );
 
         if( errorType == dsockets::ErrorType::NONE ) {
-			for( const auto s : *reSocketsList ) {
+			for( const auto& s : *reSocketsList ) {
 				//std::cout << "INFO: process re-events sockets list." << std::endl;
 				if(s->socketType() == dsockets::SocketType::UNIX) {
 					std::cout << "INFO: unix socket activity." << std::endl;


### PR DESCRIPTION
Setup more strcited warning mode for debug cmake build type.

mydisp.cpp:
- fixed: range-loop-construct warning in iterate response sockets list.

Closes #12 