### PR TITLE
DONE: #14 Use logger for messages.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive    
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        submodules: recursive    
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "spdlog"]
+	path = spdlog
+	url = https://github.com/gabime/spdlog.git
+	branch = v1.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ set(CMAKE_CXX_FLAGS_SANITIZE "-Wall -Wpedantic -Werror -ggdb -fsanitize=address 
 
 find_package(OpenSSL REQUIRED)
 
+add_custom_target(
+	spdlog ALL
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include
+	COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/spdlog/include ${CMAKE_BINARY_DIR}/include
+	)
+
+include_directories(${CMAKE_BINARY_DIR}/include)
+
 add_executable(mylsnr
 	mylsnr.cpp
 	utils.cpp

--- a/InitSsl.cpp
+++ b/InitSsl.cpp
@@ -21,6 +21,7 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <iostream>
+#include "utils.h"
 
 namespace dsockets {
 namespace ssl {
@@ -33,13 +34,11 @@ namespace {
 	std::string keyFilePassword;
 	int pass_user_password_cb(char *buf, int size, int rwflag, void *userdata)
 	{
-		std::cout << "IN pass_user_password_cb: \""
-				<< keyFilePassword
-				<< "\" data size="
-				<< keyFilePassword.size()
-				<< " try to open file: "
-				<< (const char*)userdata
-				<< std::endl;
+		logger->debug(
+			"IN pass_user_password_cb: \"{}\" data size={} try to open file: {}",
+			keyFilePassword,
+			keyFilePassword.size(),
+			(const char*)userdata);
 		if(size > 0 && keyFilePassword.size() > static_cast<size_t>(size)) {
 			return 0;
 		}
@@ -81,7 +80,7 @@ int createContext(
 	if(errorCode != 1) {
 		sslError = ERR_get_error();
 		ERR_error_string(errorCode, errorTextBuffer);
-		fprintf(stderr,"Can’t read certificate file\"%s\": %s\n", crtFile.c_str(), errorTextBuffer);
+		logger->error("Can’t read certificate file \"{}\": {}", crtFile.c_str(), errorTextBuffer);
 		SSL_CTX_free(sslGlobalCtx);
 		sslGlobalCtx = nullptr;
 		return sslError;
@@ -94,7 +93,7 @@ int createContext(
 	if(errorCode != 1) {
 		sslError = ERR_get_error();
 		ERR_error_string(errorCode, errorTextBuffer);
-		fprintf(stderr,"Can’t read key file \"%s\": %s\n", keyFile.c_str(), errorTextBuffer);
+		logger->error("Can’t read key file \"{}\": {}", keyFile.c_str(), errorTextBuffer);
 		SSL_CTX_free(sslGlobalCtx);
 		sslGlobalCtx = nullptr;
 		return sslError;
@@ -105,7 +104,7 @@ int createContext(
 	if(errorCode != 1) {
 		sslError = ERR_get_error();
 		ERR_error_string(errorCode, errorTextBuffer);
-		fprintf(stderr,"Can’t read CA list \"%s\": %s\n", caFile.c_str(), errorTextBuffer);
+		logger->error("Can’t read CA list \"{}\": {}\n", caFile.c_str(), errorTextBuffer);
 		SSL_CTX_free(sslGlobalCtx);
 		sslGlobalCtx = nullptr;
 		return sslError;

--- a/Socket.cpp
+++ b/Socket.cpp
@@ -16,17 +16,17 @@
 
 #include "Socket.h"
 #include <unistd.h>
-
+#include "utils.h"
 #include <iostream>
 
 namespace dsockets {
 
 Socket::~Socket() {
 	if(!_protectDescriptor) {
-		std::cerr << "Socket::~Socket closing descriptor." << std::endl;
+		logger->debug("Socket::~Socket closing descriptor.");
 		close(_descriptor);
 	}
-	std::cerr << "Socket::~Socket( " << _descriptor << ", " << static_cast<int>(_socketType) << " )" << std::endl;
+	logger->debug("Socket::~Socket({},{})", _descriptor, static_cast<int>(_socketType));
 }
 
 Socket::Ptr Socket::acceptConnection() {

--- a/SocketsPoller.cpp
+++ b/SocketsPoller.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
+#include "utils.h"
 
 namespace dsockets {
 
@@ -61,10 +62,10 @@ ErrorType SocketsPollerImpl::pollSockets(const SocketsList::Ptr inputSockets, So
     if(retVal == -1) {
         error = errno;
         if(error == EINTR) {
-            fprintf(stderr,"dispatch poll interrupted\n");
+            logger->warn("dispatch poll interrupted");
         	return ErrorType::INTERRUPTED;
         }
-        fprintf(stderr,"dispatch child poll failed: [%d] \"%s\"\n", errno, strerror(errno));
+        logger->error("dispatch child poll failed: [{}] \"{}\"\n", errno, strerror(errno));
         return ErrorType::ERROR;
     } else if(retVal == 0) {
         return ErrorType::TIMEOUT;
@@ -76,7 +77,7 @@ ErrorType SocketsPollerImpl::pollSockets(const SocketsList::Ptr inputSockets, So
         	index++;
         	continue;
         }
-        printf("check clients socket [%d:%d:0x%0X] \n", pollInfo[index].fd, static_cast<int>(socket->socketType()), pollInfo[index].revents);
+        logger->info("check clients socket [{}:{}:0x{:X}]", pollInfo[index].fd, static_cast<int>(socket->socketType()), pollInfo[index].revents);
     	socket->revents(pollInfo[index].revents);
     	index++;
     	outputSockets->putSocket(socket);

--- a/TcpListenerSocketFactory.cpp
+++ b/TcpListenerSocketFactory.cpp
@@ -39,10 +39,10 @@ public:
 	    socklen_t peer_size = sizeof(peer_addr);
 	    newfd = accept(descriptor(),(sockaddr*)&peer_addr,&peer_size);
 	    if( newfd < 0 ) {
-	        fprintf(stderr,"accept failed: %s\n", strerror(errno));
+	        logger->error("accept failed: {}", strerror(errno));
 	        return {};
 	    }
-	    printf("Incoming Tcp Connection Has Accepted\n");
+	    logger->info("Incoming Tcp Connection Has Accepted");
 	    return std::make_shared<Socket>(newfd, SocketType::TCP, false);
 	}
 };
@@ -73,8 +73,9 @@ Socket::Ptr TcpListenerSocketFactory::createSocket()
 
     int sockopt = 1;
     retVal = setsockopt( socketfd, SOL_SOCKET, SO_REUSEADDR, &sockopt, sizeof(int) );
-    if( retVal == -1 ) { perror("set reuse address failed"); }
-
+    if( retVal == -1 ) { 
+		logger->error("set reuse address: {}", strerror(errno));
+	}
     retVal = bind( socketfd, (sockaddr*)&srv_addr, sizeof(srv_addr) );
     if(retVal < 0 ) return {};
     retVal = listen( socketfd, _queueLength);

--- a/TcpSslListenerSocketFactory.cpp
+++ b/TcpSslListenerSocketFactory.cpp
@@ -49,16 +49,16 @@ public:
 	    socklen_t peer_size = sizeof(peer_addr);
 	    newfd = accept(descriptor(),(sockaddr*)&peer_addr,&peer_size);
 	    if( newfd < 0 ) {
-	        fprintf(stderr,"accept failed: %s\n", strerror(errno));
+	        logger->error("accept failed: {}", strerror(errno));
 	        return {};
 	    }
-	    printf("Incoming Tcp SSL Connection Has Accepted\n");
+	    logger->info("Incoming Tcp SSL Connection Has Accepted");
 		BIO *sbio = BIO_new_socket(newfd, BIO_NOCLOSE);
 		SSL *ssl = SSL_new(_sslCtx);
 		SSL_set_bio(ssl, sbio, sbio);
 		retVal = SSL_accept(ssl);
 		if( retVal <= 0 ) {
-	        fprintf(stderr,"SSL accept error: %d\n", SSL_get_error(ssl,retVal));
+	        logger->error("SSL accept error: {}", SSL_get_error(ssl,retVal));
 	        return {};
 		}
 	    return std::make_shared<Socket>(newfd, SocketType::SSL, false);
@@ -93,7 +93,9 @@ Socket::Ptr TcpSslListenerSocketFactory::createSocket()
 
     int sockopt = 1;
     retVal = setsockopt( socketfd, SOL_SOCKET, SO_REUSEADDR, &sockopt, sizeof(int) );
-    if( retVal == -1 ) { perror("set reuse address failed"); }
+    if( retVal == -1 ) { 
+		logger->error("set reuse address: {}",strerror(errno));
+	}
 
     retVal = bind( socketfd, (sockaddr*)&srv_addr, sizeof(srv_addr) );
     if(retVal < 0 ) return {};

--- a/UnixListenerSocketFactory.cpp
+++ b/UnixListenerSocketFactory.cpp
@@ -44,10 +44,10 @@ public:
 	Socket::Ptr acceptConnection() override {
 	    int new_fd = accept( descriptor(), NULL, NULL);
 	    if (new_fd < 0) {
-	        fprintf(stderr,"accept dispatcher connection failed: %s\n", strerror(errno));
+	        logger->error("accept dispatcher connection failed: {}", strerror(errno));
 	        return {};
 	    }
-	    printf("Dispatcher Connection Has Accepted\n");
+	    logger->info("Dispatcher Connection Has Accepted");
 	    return std::make_shared<Socket>(new_fd, SocketType::UNIX, false);
 	}
 

--- a/UnixSocketFactory.cpp
+++ b/UnixSocketFactory.cpp
@@ -56,7 +56,7 @@ Socket::Ptr UnixSocketFactory::createSocket()
     size_t len = strlen(my_addr.sun_path) + sizeof(my_addr.sun_family);
     int retVal = connect(sfd, (struct sockaddr *) &my_addr, len);
     if( retVal < 0 ) {
-        fprintf(stderr,"Connect failed: [%s]\n", strerror(errno));
+        logger->error("Connect failed: [{}]", strerror(errno));
         return {};
     }
 

--- a/myclnt.cpp
+++ b/myclnt.cpp
@@ -18,18 +18,19 @@
 #include "SocketFactory.h"
 #include "SocketUtils.h"
 #include "InitSsl.h"
-
+#include "utils.h"
 #include <string>
 #include <stdexcept>
 #include <iostream>
 
 int main(int argc, char *argv[])
 try {
+	create_logger("client");
 	dsockets::ssl::createClientContext();
 	dsockets::utility::SocketFactory::Ptr socketFactory = dsockets::utility::createTcpSslConnectSocketFactory("localhost", 5555);
 	dsockets::Socket::Ptr clientSocket = socketFactory->createSocket();
 	if(!clientSocket) {
-		std::cerr << "connect failed." << std::endl;
+		logger->critical("connect failed.");
 		return 1;
 	}
 	while(true) {
@@ -40,14 +41,14 @@ try {
 		}
 		std::string userInputLine;
 		std::cin >> userInputLine;
-		dsockets::utils::write(clientSocket,userInputLine);
 		if(userInputLine.empty()) {
 			dsockets::utils::write(clientSocket,"EXIT");
 			break;
 		}
+		dsockets::utils::write(clientSocket,userInputLine);
 	}
 	return 0;
 } catch(const std::exception &e) {
-	std::cerr << "Exception: " << e.what() << std::endl;
-	return 13;
+	logger->critical("Exception: {}", e.what());
+	return 1;
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -17,6 +17,16 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include "utils.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+std::shared_ptr<spdlog::logger> logger = spdlog::stdout_color_mt("default");
+
+void create_logger(const char* process_name)
+{
+    logger = spdlog::stdout_color_mt(process_name);
+}
+
 
 bool setnonblocking(int sock)
 {

--- a/utils.h
+++ b/utils.h
@@ -17,6 +17,10 @@
 #ifndef __MY__UTILS_H__
 #define __MY__UTILS_H__
 
+#include "spdlog/spdlog.h"
+
 bool setnonblocking(int sock);
+void create_logger(const char* process_name);
+extern std::shared_ptr<spdlog::logger> logger;
 
 #endif //__MY__UTILS_H__


### PR DESCRIPTION
Added: submodule gabime/spdlog.
Added: global spdlog instance - logger.
Replaced all printf, fprintf, std::cout and std::cerr to logger methods.
Closes #14 